### PR TITLE
fix: allow relaying based on first block

### DIFF
--- a/relayer/chains/cosmos/cosmos_chain_processor.go
+++ b/relayer/chains/cosmos/cosmos_chain_processor.go
@@ -382,7 +382,6 @@ func (ccp *CosmosChainProcessor) queryCycle(ctx context.Context, persistence *qu
 	firstTimeInSync := false
 
 	if !ccp.inSync {
-		// latest height < latest queried height + 2
 		if (persistence.latestHeight - persistence.latestQueriedBlock) < int64(ccp.inSyncNumBlocksThreshold) {
 			ccp.inSync = true
 			firstTimeInSync = true

--- a/relayer/chains/cosmos/cosmos_chain_processor.go
+++ b/relayer/chains/cosmos/cosmos_chain_processor.go
@@ -382,7 +382,8 @@ func (ccp *CosmosChainProcessor) queryCycle(ctx context.Context, persistence *qu
 	firstTimeInSync := false
 
 	if !ccp.inSync {
-		if (persistence.latestHeight - persistence.latestQueriedBlock) < defaultInSyncNumBlocksThreshold {
+		// latest height < latest queried height + 2
+		if (persistence.latestHeight - persistence.latestQueriedBlock) < int64(ccp.inSyncNumBlocksThreshold) {
 			ccp.inSync = true
 			firstTimeInSync = true
 			ccp.log.Info("Chain is in sync")

--- a/relayer/chains/cosmos/cosmos_chain_processor.go
+++ b/relayer/chains/cosmos/cosmos_chain_processor.go
@@ -532,6 +532,8 @@ func (ccp *CosmosChainProcessor) queryCycle(ctx context.Context, persistence *qu
 			continue
 		}
 
+		ccp.log.Debug("sending new data to the path processor", zap.Bool("inSync", ccp.inSync))
+
 		pp.HandleNewData(chainID, processor.ChainProcessorCacheData{
 			LatestBlock:          ccp.latestBlock,
 			LatestHeader:         latestHeader,

--- a/relayer/chains/cosmos/cosmos_chain_processor.go
+++ b/relayer/chains/cosmos/cosmos_chain_processor.go
@@ -507,7 +507,7 @@ func (ccp *CosmosChainProcessor) queryCycle(ctx context.Context, persistence *qu
 		}
 	}
 
-	if newLatestQueriedBlock == persistence.latestQueriedBlock {
+	if newLatestQueriedBlock == persistence.latestQueriedBlock && !firstTimeInSync {
 		return nil
 	}
 

--- a/relayer/chains/cosmos/cosmos_chain_processor.go
+++ b/relayer/chains/cosmos/cosmos_chain_processor.go
@@ -57,7 +57,7 @@ type CosmosChainProcessor struct {
 
 	inSyncNumBlocksThreshold int
 
-	firstEverUpdateHasPassed bool
+	firstEverUpdateIsAlreadyDone bool
 }
 
 type Option func(*CosmosChainProcessor)
@@ -509,7 +509,9 @@ func (ccp *CosmosChainProcessor) queryCycle(ctx context.Context, persistence *qu
 		}
 	}
 
-	if ccp.firstEverUpdateHasPassed {
+	if ccp.firstEverUpdateIsAlreadyDone || !firstTimeInSync {
+		// after the first update, or if we are not in sync on the first update, we might want to avoid sending data to path processors if we didn't query anything new
+
 		if newLatestQueriedBlock == persistence.latestQueriedBlock {
 			ccp.log.Debug("didnt query anything new, not sending data to path processors")
 			return nil
@@ -551,7 +553,7 @@ func (ccp *CosmosChainProcessor) queryCycle(ctx context.Context, persistence *qu
 		})
 	}
 
-	ccp.firstEverUpdateHasPassed = true
+	ccp.firstEverUpdateIsAlreadyDone = true
 
 	persistence.latestQueriedBlock = newLatestQueriedBlock
 

--- a/relayer/chains/cosmos/cosmos_chain_processor.go
+++ b/relayer/chains/cosmos/cosmos_chain_processor.go
@@ -411,8 +411,9 @@ func (ccp *CosmosChainProcessor) queryCycle(ctx context.Context, persistence *qu
 	chainID := ccp.chainProvider.ChainId()
 
 	firstHeightToQuery := persistence.latestQueriedBlock
+	// On the first ever update, we want to make sure we propagate the block info to the path processor
+	// Afterward, we only want to query new blocks
 	if ccp.firstEverUpdateIsAlreadyDone {
-		// TODO: explain
 		firstHeightToQuery++
 	}
 

--- a/relayer/chains/cosmos/cosmos_chain_processor.go
+++ b/relayer/chains/cosmos/cosmos_chain_processor.go
@@ -263,14 +263,13 @@ func (ccp *CosmosChainProcessor) Run(ctx context.Context, initialBlockHistory ui
 	}
 
 	// this will make initial QueryLoop iteration look back initialBlockHistory blocks in history
-	// TODO(danwt): I'm assuming initial block history is always zero right now
 	latestQueriedBlock := persistence.latestHeight - int64(initialBlockHistory)
 
 	if latestQueriedBlock < 0 {
 		latestQueriedBlock = 0
 	}
 
-	if stuckPacket != nil && ccp.chainProvider.ChainId() == stuckPacket.ChainID { // TODO(danwt): check if can use stuck packet
+	if stuckPacket != nil && ccp.chainProvider.ChainId() == stuckPacket.ChainID {
 		latestQueriedBlock = int64(stuckPacket.StartHeight)
 	}
 

--- a/relayer/chains/cosmos/cosmos_chain_processor.go
+++ b/relayer/chains/cosmos/cosmos_chain_processor.go
@@ -57,7 +57,8 @@ type CosmosChainProcessor struct {
 
 	inSyncNumBlocksThreshold int
 
-	firstEverUpdateIsAlreadyDone bool
+	firstEverQueryIsAlreadyDone bool
+	firstEverSyncIsAlreadyDone  bool
 }
 
 type Option func(*CosmosChainProcessor)
@@ -412,7 +413,7 @@ func (ccp *CosmosChainProcessor) queryCycle(ctx context.Context, persistence *qu
 	firstHeightToQuery := persistence.latestQueriedBlock
 	// On the first ever update, we want to make sure we propagate the block info to the path processor
 	// Afterward, we only want to query new blocks
-	if ccp.firstEverUpdateIsAlreadyDone {
+	if ccp.firstEverQueryIsAlreadyDone {
 		firstHeightToQuery++
 	}
 
@@ -517,7 +518,7 @@ func (ccp *CosmosChainProcessor) queryCycle(ctx context.Context, persistence *qu
 		}
 	}
 
-	if ccp.firstEverUpdateIsAlreadyDone && newLatestQueriedBlock == persistence.latestQueriedBlock {
+	if ccp.firstEverSyncIsAlreadyDone && newLatestQueriedBlock == persistence.latestQueriedBlock {
 		return nil
 	}
 
@@ -558,7 +559,11 @@ func (ccp *CosmosChainProcessor) queryCycle(ctx context.Context, persistence *qu
 
 	persistence.latestQueriedBlock = newLatestQueriedBlock
 
-	ccp.firstEverUpdateIsAlreadyDone = true
+	if ccp.inSync {
+		ccp.firstEverSyncIsAlreadyDone = true
+	}
+
+	ccp.firstEverQueryIsAlreadyDone = true
 
 	return nil
 }

--- a/relayer/chains/cosmos/cosmos_chain_processor.go
+++ b/relayer/chains/cosmos/cosmos_chain_processor.go
@@ -57,7 +57,6 @@ type CosmosChainProcessor struct {
 
 	inSyncNumBlocksThreshold int
 
-	// firstEverQueryIsAlreadyDone bool
 	firstEverSyncIsAlreadyDone bool
 }
 
@@ -562,8 +561,6 @@ func (ccp *CosmosChainProcessor) queryCycle(ctx context.Context, persistence *qu
 	if ccp.inSync {
 		ccp.firstEverSyncIsAlreadyDone = true
 	}
-
-	// ccp.firstEverQueryIsAlreadyDone = true
 
 	return nil
 }

--- a/relayer/chains/cosmos/cosmos_chain_processor.go
+++ b/relayer/chains/cosmos/cosmos_chain_processor.go
@@ -518,7 +518,6 @@ func (ccp *CosmosChainProcessor) queryCycle(ctx context.Context, persistence *qu
 	}
 
 	if ccp.firstEverUpdateIsAlreadyDone && newLatestQueriedBlock == persistence.latestQueriedBlock {
-		ccp.log.Debug("didnt query anything new, not sending data to path processors")
 		return nil
 	}
 

--- a/relayer/chains/cosmos/cosmos_chain_processor.go
+++ b/relayer/chains/cosmos/cosmos_chain_processor.go
@@ -57,8 +57,8 @@ type CosmosChainProcessor struct {
 
 	inSyncNumBlocksThreshold int
 
-	firstEverQueryIsAlreadyDone bool
-	firstEverSyncIsAlreadyDone  bool
+	// firstEverQueryIsAlreadyDone bool
+	firstEverSyncIsAlreadyDone bool
 }
 
 type Option func(*CosmosChainProcessor)
@@ -413,7 +413,7 @@ func (ccp *CosmosChainProcessor) queryCycle(ctx context.Context, persistence *qu
 	firstHeightToQuery := persistence.latestQueriedBlock
 	// On the first ever update, we want to make sure we propagate the block info to the path processor
 	// Afterward, we only want to query new blocks
-	if ccp.firstEverQueryIsAlreadyDone {
+	if ccp.firstEverSyncIsAlreadyDone {
 		firstHeightToQuery++
 	}
 
@@ -563,7 +563,7 @@ func (ccp *CosmosChainProcessor) queryCycle(ctx context.Context, persistence *qu
 		ccp.firstEverSyncIsAlreadyDone = true
 	}
 
-	ccp.firstEverQueryIsAlreadyDone = true
+	// ccp.firstEverQueryIsAlreadyDone = true
 
 	return nil
 }

--- a/relayer/client.go
+++ b/relayer/client.go
@@ -24,7 +24,8 @@ func (c *Chain) CreateClients(ctx context.Context,
 	customClientTrustingPeriod,
 	maxClockDrift time.Duration,
 	customClientTrustingPeriodPercentage int64,
-	memo string) (string, string, error) {
+	memo string,
+) (string, string, error) {
 	// Query the latest heights on src and dst and retry if the query fails
 	var srch, dsth int64
 	if err := retry.Do(func() error {
@@ -64,7 +65,7 @@ func (c *Chain) CreateClients(ctx context.Context,
 	}
 
 	// overriding the unbonding period should only be possible when creating single clients at a time (CreateClient)
-	var overrideUnbondingPeriod = time.Duration(0)
+	overrideUnbondingPeriod := time.Duration(0)
 
 	var clientSrc, clientDst string
 	eg, egCtx := errgroup.WithContext(ctx)
@@ -126,7 +127,8 @@ func CreateClient(
 	overrideUnbondingPeriod,
 	maxClockDrift time.Duration,
 	customClientTrustingPeriodPercentage int64,
-	memo string) (string, error) {
+	memo string,
+) (string, error) {
 	// If a client ID was specified in the path and override is not set, ensure the client exists.
 	if !override && src.PathEnd.ClientID != "" {
 		// TODO: check client is not expired
@@ -316,7 +318,7 @@ func MsgUpdateClient(
 	eg.Go(func() error {
 		return retry.Do(func() error {
 			var err error
-			dstTrustedHeader, err = src.ChainProvider.QueryIBCHeader(egCtx, int64(dstClientState.GetLatestHeight().GetRevisionHeight()))
+			dstTrustedHeader, err = src.ChainProvider.QueryIBCHeader(egCtx, int64(dstClientState.GetLatestHeight().GetRevisionHeight())+1) // TODO: check
 			return err
 		}, retry.Context(egCtx), RtyAtt, RtyDel, RtyErr, retry.OnRetry(func(n uint, err error) {
 			src.log.Info(
@@ -518,7 +520,6 @@ func findMatchingClient(ctx context.Context, src, dst *Chain, newClientState ibc
 
 	for _, existingClientState := range clientsResp {
 		clientID, err := provider.ClientsMatch(ctx, src.ChainProvider, dst.ChainProvider, existingClientState, newClientState)
-
 		// If there is an error parsing/type asserting the client state in ClientsMatch this is going
 		// to make the entire find matching client logic fail.
 		// We should really never be encountering an error here and if we do it is probably a sign of a

--- a/relayer/client.go
+++ b/relayer/client.go
@@ -318,7 +318,7 @@ func MsgUpdateClient(
 	eg.Go(func() error {
 		return retry.Do(func() error {
 			var err error
-			dstTrustedHeader, err = src.ChainProvider.QueryIBCHeader(egCtx, int64(dstClientState.GetLatestHeight().GetRevisionHeight())+1) // TODO: check
+			dstTrustedHeader, err = src.ChainProvider.QueryIBCHeader(egCtx, int64(dstClientState.GetLatestHeight().GetRevisionHeight())+1)
 			return err
 		}, retry.Context(egCtx), RtyAtt, RtyDel, RtyErr, retry.OnRetry(func(n uint, err error) {
 			src.log.Info(

--- a/relayer/processor/message_processor.go
+++ b/relayer/processor/message_processor.go
@@ -295,11 +295,15 @@ func (mp *messageProcessor) assembleMsgUpdateClient(ctx context.Context, src, ds
 		trustedNextValidatorsHash = header.NextValidatorsHash()
 	}
 
-	// As we only require one chain to be in sync the src.latestHeader may be nil. In that case
-	// we want to skip it
-	if src.latestHeader == nil {
-		return fmt.Errorf("latest header is nil for chain_id: %s. Waiting for catching up", src.info.ChainID)
-	}
+	/*
+		// As we only require one chain to be in sync the src.latestHeader may be nil. In that case
+		// we want to skip it
+		if src.latestHeader == nil {
+			return fmt.Errorf("latest header is nil for chain_id: %s. Waiting for catching up", src.info.ChainID)
+		}
+		TODO: check
+	*/
+
 	if src.latestHeader.Height() == trustedConsensusHeight.RevisionHeight &&
 		!bytes.Equal(src.latestHeader.NextValidatorsHash(), trustedNextValidatorsHash) {
 		return fmt.Errorf("latest header height is equal to the client trusted height: %d, "+
@@ -475,7 +479,7 @@ func (mp *messageProcessor) sendBatchMessages(
 	}
 	callbacks := []func(rtr *provider.RelayerTxResponse, err error){callback}
 
-	//During testing, this adds a callback so our test case can inspect the TX results
+	// During testing, this adds a callback so our test case can inspect the TX results
 	if PathProcMessageCollector != nil {
 		testCallback := func(rtr *provider.RelayerTxResponse, err error) {
 			msgResult := &PathProcessorMessageResp{
@@ -562,7 +566,7 @@ func (mp *messageProcessor) sendSingleMessage(
 
 	callbacks = append(callbacks, callback)
 
-	//During testing, this adds a callback so our test case can inspect the TX results
+	// During testing, this adds a callback so our test case can inspect the TX results
 	if PathProcMessageCollector != nil {
 		testCallback := func(rtr *provider.RelayerTxResponse, err error) {
 			msgResult := &PathProcessorMessageResp{

--- a/relayer/processor/message_processor.go
+++ b/relayer/processor/message_processor.go
@@ -104,17 +104,21 @@ func (mp *messageProcessor) processMessages(
 		var err error
 		needsClientUpdate, err = mp.shouldUpdateClientNow(ctx, src, dst)
 		if err != nil {
-			return err
+			return fmt.Errorf("should update client now: %w", err)
 		}
 
 		if err := mp.assembleMsgUpdateClient(ctx, src, dst); err != nil {
-			return err
+			return fmt.Errorf("assemble message update client: %w", err)
 		}
 	}
 
 	mp.assembleMessages(ctx, messages, src, dst)
 
-	return mp.trackAndSendMessages(ctx, src, dst, needsClientUpdate)
+	if err := mp.trackAndSendMessages(ctx, src, dst, needsClientUpdate); err != nil {
+		return fmt.Errorf("track and send messages: %w", err)
+	}
+
+	return nil
 }
 
 func isLocalhostClient(srcClientID, dstClientID string) bool {
@@ -136,7 +140,7 @@ func (mp *messageProcessor) shouldUpdateClientNow(ctx context.Context, src, dst 
 	if dst.clientState.ConsensusTime.IsZero() {
 		h, err := src.chainProvider.QueryIBCHeader(ctx, int64(dst.clientState.ConsensusHeight.RevisionHeight))
 		if err != nil {
-			return false, fmt.Errorf("failed to get header height: %w", err)
+			return false, fmt.Errorf("query ibc header: %w", err)
 		}
 		consensusHeightTime = time.Unix(0, int64(h.ConsensusState().GetTimestamp()))
 	} else {
@@ -166,16 +170,18 @@ func (mp *messageProcessor) shouldUpdateClientNow(ctx context.Context, src, dst 
 		mp.metrics.SetClientTrustingPeriod(src.info.PathName, dst.info.ChainID, dst.info.ClientID, time.Duration(dst.clientState.TrustingPeriod))
 	}
 
-	if shouldUpdateClientNow {
-		mp.log.Info("Client update threshold condition met",
-			zap.String("path_name", src.info.PathName),
-			zap.String("chain_id", dst.info.ChainID),
-			zap.String("client_id", dst.info.ClientID),
-			zap.Int64("trusting_period", dst.clientState.TrustingPeriod.Milliseconds()),
-			zap.Int64("time_since_client_update", time.Since(consensusHeightTime).Milliseconds()),
-			zap.Int64("client_threshold_time", mp.clientUpdateThresholdTime.Milliseconds()),
-		)
-	}
+	mp.log.Debug("should update client now?",
+		zap.String("path_name", src.info.PathName),
+		zap.String("chain_id", dst.info.ChainID),
+		zap.String("client_id", dst.info.ClientID),
+		zap.Int64("trusting_period", dst.clientState.TrustingPeriod.Milliseconds()),
+		zap.Int64("time_since_client_update", time.Since(consensusHeightTime).Milliseconds()),
+		zap.Int64("client_threshold_time", mp.clientUpdateThresholdTime.Milliseconds()),
+		zap.Bool("enough_blocks_passed", enoughBlocksPassed),
+		zap.Bool("past_two_thirds_trusting_period", pastTwoThirdsTrustingPeriod),
+		zap.Bool("past_configured_client_update_threshold", pastConfiguredClientUpdateThreshold),
+		zap.Bool("should_update_client_now", shouldUpdateClientNow),
+	)
 
 	return shouldUpdateClientNow, nil
 }
@@ -317,12 +323,12 @@ func (mp *messageProcessor) assembleMsgUpdateClient(ctx context.Context, src, ds
 		dst.clientTrustedState.IBCHeader,
 	)
 	if err != nil {
-		return fmt.Errorf("error assembling new client header: %w", err)
+		return fmt.Errorf("msg update client header: %w", err)
 	}
 
 	msgUpdateClient, err := dst.chainProvider.MsgUpdateClient(clientID, msgUpdateClientHeader)
 	if err != nil {
-		return fmt.Errorf("error assembling MsgUpdateClient: %w", err)
+		return fmt.Errorf("msg update client: %w", err)
 	}
 
 	mp.msgUpdateClient = msgUpdateClient

--- a/relayer/processor/message_processor.go
+++ b/relayer/processor/message_processor.go
@@ -301,15 +301,6 @@ func (mp *messageProcessor) assembleMsgUpdateClient(ctx context.Context, src, ds
 		trustedNextValidatorsHash = header.NextValidatorsHash()
 	}
 
-	/*
-		// As we only require one chain to be in sync the src.latestHeader may be nil. In that case
-		// we want to skip it
-		if src.latestHeader == nil {
-			return fmt.Errorf("latest header is nil for chain_id: %s. Waiting for catching up", src.info.ChainID)
-		}
-		TODO: check
-	*/
-
 	if src.latestHeader.Height() == trustedConsensusHeight.RevisionHeight &&
 		!bytes.Equal(src.latestHeader.NextValidatorsHash(), trustedNextValidatorsHash) {
 		return fmt.Errorf("latest header height is equal to the client trusted height: %d, "+

--- a/relayer/processor/path_end_runtime.go
+++ b/relayer/processor/path_end_runtime.go
@@ -476,6 +476,8 @@ func (pathEnd *pathEndRuntime) mergeCacheData(
 	pathEnd.lastClientUpdateHeightMu.Unlock()
 
 	pathEnd.inSync = d.InSync
+	pathEnd.log.Debug("set in sync", zap.Bool("in_sync", pathEnd.inSync), zap.String("chain_id", pathEnd.info.ChainID))
+
 	pathEnd.latestHeader = d.LatestHeader
 	pathEnd.clientState = d.ClientState
 

--- a/relayer/processor/path_end_runtime.go
+++ b/relayer/processor/path_end_runtime.go
@@ -472,6 +472,10 @@ func (pathEnd *pathEndRuntime) mergeCacheData(
 	memoLimit, maxReceiverSize int,
 ) {
 	pathEnd.lastClientUpdateHeightMu.Lock()
+	var zero provider.LatestBlock
+	if d.LatestBlock == zero {
+		pathEnd.log.Error("received zero type latest block", zap.String("chain_id", pathEnd.info.ChainID))
+	}
 	pathEnd.latestBlock = d.LatestBlock
 	pathEnd.lastClientUpdateHeightMu.Unlock()
 

--- a/relayer/processor/path_end_runtime.go
+++ b/relayer/processor/path_end_runtime.go
@@ -472,9 +472,10 @@ func (pathEnd *pathEndRuntime) mergeCacheData(
 	memoLimit, maxReceiverSize int,
 ) {
 	pathEnd.lastClientUpdateHeightMu.Lock()
-	var zero provider.LatestBlock
-	if d.LatestBlock == zero {
-		pathEnd.log.Error("received zero type latest block", zap.String("chain_id", pathEnd.info.ChainID))
+	var zeroType provider.LatestBlock
+	if d.LatestBlock == zeroType {
+		// sanity check
+		panic("received zero type latest block")
 	}
 	pathEnd.latestBlock = d.LatestBlock
 	pathEnd.lastClientUpdateHeightMu.Unlock()

--- a/relayer/processor/path_processor.go
+++ b/relayer/processor/path_processor.go
@@ -420,6 +420,7 @@ func (pp *PathProcessor) Run(ctx context.Context, cancel func()) {
 
 		// process latest message cache state from both pathEnds
 		if err := pp.processLatestMessages(ctx, cancel); err != nil {
+			pp.log.Debug("error process latest messages", zap.Error(err))
 			// in case of IBC message send errors, schedule retry after durationErrorRetry
 			if retryTimer != nil {
 				retryTimer.Stop()

--- a/relayer/processor/path_processor.go
+++ b/relayer/processor/path_processor.go
@@ -406,6 +406,7 @@ func (pp *PathProcessor) Run(ctx context.Context, cancel func()) {
 			}
 		}
 
+		pp.log.Debug("path processor run: are the chains in sync? ", zap.Bool("pathEnd1", pp.pathEnd1.inSync), zap.Bool("pathEnd2", pp.pathEnd2.inSync))
 		if !pp.pathEnd1.inSync || !pp.pathEnd2.inSync { // TODO: check
 			continue
 		}

--- a/relayer/processor/path_processor.go
+++ b/relayer/processor/path_processor.go
@@ -406,7 +406,7 @@ func (pp *PathProcessor) Run(ctx context.Context, cancel func()) {
 			}
 		}
 
-		if !pp.pathEnd1.inSync && !pp.pathEnd2.inSync {
+		if !pp.pathEnd1.inSync || !pp.pathEnd2.inSync { // TODO: check
 			continue
 		}
 

--- a/relayer/processor/path_processor.go
+++ b/relayer/processor/path_processor.go
@@ -391,7 +391,7 @@ func (pp *PathProcessor) processAvailableSignals(ctx context.Context, cancel fun
 func (pp *PathProcessor) Run(ctx context.Context, cancel func()) {
 	var retryTimer *time.Timer
 
-	pp.flushTimer = time.NewTimer(time.Hour)
+	pp.flushTimer = time.NewTimer(pp.flushInterval)
 
 	for {
 		// block until we have any signals to process

--- a/relayer/processor/path_processor.go
+++ b/relayer/processor/path_processor.go
@@ -407,7 +407,7 @@ func (pp *PathProcessor) Run(ctx context.Context, cancel func()) {
 		}
 
 		pp.log.Debug("path processor run: are the chains in sync? ", zap.Bool("pathEnd1", pp.pathEnd1.inSync), zap.Bool("pathEnd2", pp.pathEnd2.inSync))
-		if !pp.pathEnd1.inSync || !pp.pathEnd2.inSync { // TODO: check
+		if !pp.pathEnd1.inSync || !pp.pathEnd2.inSync {
 			continue
 		}
 

--- a/relayer/strategies.go
+++ b/relayer/strategies.go
@@ -62,7 +62,7 @@ func StartRelayer(
 			var p processor.ChainProcessor
 			if chainID == paths[0].Path.Src.ChainID {
 				// Rollapp
-				p = chain.chainProcessor(log, metrics, cosmos.WithInSyncNumBlocksThreshold(0))
+				p = chain.chainProcessor(log, metrics, cosmos.WithInSyncNumBlocksThreshold(1))
 			} else {
 				p = chain.chainProcessor(log, metrics)
 			}

--- a/relayer/strategies.go
+++ b/relayer/strategies.go
@@ -60,9 +60,9 @@ func StartRelayer(
 
 		for chainID, chain := range chains {
 			var p processor.ChainProcessor
-			if chainID == paths[0].Path.Src.ChainID {
+			if 0 < len(paths) && chainID == paths[0].Path.Src.ChainID {
 				// Rollapp
-				threshold := 2 // same as default
+				threshold := 2 // same as default, TODO(danwt): configure if necessary
 				p = chain.chainProcessor(log, metrics, cosmos.WithInSyncNumBlocksThreshold(threshold))
 			} else {
 				p = chain.chainProcessor(log, metrics)

--- a/relayer/strategies.go
+++ b/relayer/strategies.go
@@ -62,7 +62,8 @@ func StartRelayer(
 			var p processor.ChainProcessor
 			if chainID == paths[0].Path.Src.ChainID {
 				// Rollapp
-				p = chain.chainProcessor(log, metrics, cosmos.WithInSyncNumBlocksThreshold(1))
+				threshold := 2 // same as default
+				p = chain.chainProcessor(log, metrics, cosmos.WithInSyncNumBlocksThreshold(threshold))
 			} else {
 				p = chain.chainProcessor(log, metrics)
 			}


### PR DESCRIPTION
Old behavior:

The chain processor will only send block info to the path processor if the block is a 'new' block. It has the assumption that new blocks come frequently, so it does not consider the first block (highest at start time) a new block.

New behavior:

The chain processor will only send block info to the path processor if the block is a 'new' block. The first block is considered a new block.


Extra:

- improves error visibility in processing messages
- adds more debug logs
- removes old patch (https://github.com/dymensionxyz/go-relayer/commit/8b8e5821fdb53b68457aee24c2af67f86ade18a2)