### PR TITLE
Compare flush only version with normal version

### DIFF
--- a/dymutils/gerr/types.go
+++ b/dymutils/gerr/types.go
@@ -1,0 +1,9 @@
+package gerr
+
+import "errors"
+
+/*
+TODO: this should use the dymint gerr package
+*/
+
+var ErrNotFound = errors.New("not found")

--- a/relayer/chains/cosmos/query.go
+++ b/relayer/chains/cosmos/query.go
@@ -1064,7 +1064,7 @@ func (cc *CosmosProvider) QueryRecvPacket(
 		}
 	}
 
-	return provider.PacketInfo{}, fmt.Errorf("no ibc messages found for write_acknowledgement query: %s", q)
+	return provider.PacketInfo{}, fmt.Errorf("no ibc messages found for write_acknowledgement query: %s: %w", q, gerr.ErrNotFound)
 }
 
 // QueryUnreceivedAcknowledgements returns a list of unrelayed packet acks


### PR DESCRIPTION
This draft PR is just for convenience to see the comparison between the flush only version of the relayer, and the one used for normal operation.